### PR TITLE
Add moving average crossover example

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,26 @@
-# Trading
+# Trading Examples
+
+This repository includes a Python script demonstrating a simple Moving Average Crossover strategy for ETFs using data from Yahoo Finance.
+
+## Requirements
+
+- Python 3.8+
+- [yfinance](https://pypi.org/project/yfinance/)
+- pandas
+- matplotlib
+
+Install dependencies via pip:
+
+```bash
+pip install yfinance pandas matplotlib
+```
+
+## Usage
+
+Run the script to download data for the iShares Core MSCI World ETF (`IWDA.DE`), calculate 50-day and 200-day moving averages, simulate the strategy, and plot the performance compared with a buy & hold approach:
+
+```bash
+python ma_crossover.py
+```
+
+The plot displays the cumulative returns of the strategy versus simply holding the ETF.

--- a/ma_crossover.py
+++ b/ma_crossover.py
@@ -1,0 +1,62 @@
+import pandas as pd
+import matplotlib.pyplot as plt
+import yfinance as yf
+
+
+def download_data(ticker: str, start: str = "2018-01-01") -> pd.DataFrame:
+    """Download daily data for a ticker using yfinance."""
+    df = yf.download(ticker, start=start)
+    if df.empty:
+        raise ValueError(f"No data downloaded for {ticker}")
+    return df
+
+
+def add_indicators(df: pd.DataFrame) -> pd.DataFrame:
+    df = df.copy()
+    df["MA50"] = df["Adj Close"].rolling(window=50).mean()
+    df["MA200"] = df["Adj Close"].rolling(window=200).mean()
+    return df
+
+
+def simulate_strategy(df: pd.DataFrame) -> pd.DataFrame:
+    df = df.copy()
+    # Signal: 1 if 50 MA is above 200 MA
+    df["Signal"] = 0
+    df.loc[df["MA50"] > df["MA200"], "Signal"] = 1
+
+    # Position is previous day's signal
+    df["Position"] = df["Signal"].shift(1).fillna(0)
+
+    # Daily returns
+    df["Return"] = df["Adj Close"].pct_change()
+    df["Strategy"] = df["Position"] * df["Return"]
+
+    # Cumulative performance
+    df["BuyHold_Cum"] = (1 + df["Return"]).cumprod()
+    df["Strategy_Cum"] = (1 + df["Strategy"]).cumprod()
+
+    return df
+
+
+def plot_performance(df: pd.DataFrame, ticker: str) -> None:
+    plt.figure(figsize=(10, 6))
+    plt.plot(df.index, df["BuyHold_Cum"], label="Buy & Hold")
+    plt.plot(df.index, df["Strategy_Cum"], label="MA Crossover")
+    plt.title(f"{ticker} - Moving Average Crossover vs Buy & Hold")
+    plt.xlabel("Date")
+    plt.ylabel("Cumulative Return")
+    plt.legend()
+    plt.tight_layout()
+    plt.show()
+
+
+def main() -> None:
+    ticker = "IWDA.DE"
+    df = download_data(ticker)
+    df = add_indicators(df)
+    df = simulate_strategy(df)
+    plot_performance(df, ticker)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add a script `ma_crossover.py` that downloads data via *yfinance*
- show how to simulate a 50/200 day moving average strategy
- update README with usage instructions

## Testing
- `pip install yfinance` *(fails: Tunnel connection failed)*
- `python ma_crossover.py` *(fails: ModuleNotFoundError: No module named 'pandas')*
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683ff755e72483218ae687a14c673c1f